### PR TITLE
Gsm 2.0 refinements

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -177,7 +177,12 @@ function resolveProjectFolder(projectName) {
 // Helper: find an available Python command to run. Returns an object { cmd, args }
 // or null if none found. Order: GSM_PYTHON_EXE -> repo .venv -> py -3 (probe) -> python on PATH (probe).
 function findPythonCmd(repoRoot) {
-  const venvPython = path.join(repoRoot, '.venv', 'Scripts', process.platform === 'win32' ? 'python.exe' : 'python');
+  const venvPython = path.join(
+    repoRoot,
+    '.venv',
+    process.platform === 'win32' ? 'Scripts' : 'bin',
+    process.platform === 'win32' ? 'python.exe' : 'python'
+  );
   let pythonCmd = null;
   let pythonArgs = [];
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -165,6 +165,34 @@
   box-sizing: border-box;
 }
 
+/* Rotate field: whole-degree step buttons sit to the left of the 0.1-step input */
+.rotate-step-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.rotate-step-row input {
+  width: auto;
+}
+.step-btn {
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  background: #f7f7f7;
+  border-radius: 4px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.step-btn:hover {
+  background: #eee;
+}
+.step-btn:active {
+  transform: translateY(1px);
+}
+
 /* preview removed per user request */
 
 .toggle-btn {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -689,7 +689,7 @@ function App() {
   const [clipboardShapes, setClipboardShapes] = useState<Array<Partial<ToolShape>> | null>(null);
 
   // Lifted trace params so Load Image can include the inspector values
-  const [traceParams, setTraceParams] = useState<{ threshold: number; offset: number; token: number; resolution: number }>({ threshold: 145, offset: 0.1, token: 3.0, resolution: 20 });
+  const [traceParams, setTraceParams] = useState<{ threshold: number; offset: number; token: number; resolution: number }>({ threshold: 145, offset: 0.05, token: 3.0, resolution: 20 });
 
   function saveProjectToFile() {
     try {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -464,7 +464,7 @@ function App() {
     if (key === "rotate") {
       const v = parseFloat(raw);
       if (Number.isNaN(v)) return;
-      const rounded = Math.round(v * 1); // integer degrees
+      const rounded = Math.round(v * 10) / 10; // 0.1 degree steps
       updateShape(selectedShape.id, { rotateDeg: rounded });
       setEditFields((p) => ({ ...p, rotate: rounded.toFixed(1) }));
       return;

--- a/frontend/src/components/Canvas.tsx
+++ b/frontend/src/components/Canvas.tsx
@@ -191,7 +191,8 @@ export default function Canvas({
 
       // rotation when ctrl/meta is held and Left/Right
       if (e.ctrlKey || e.metaKey) {
-        const delta = (e.key === "ArrowLeft" ? -1 : e.key === "ArrowRight" ? 1 : 0);
+        const rotStep = e.shiftKey ? 0.1 : 1.0;
+        const delta = (e.key === "ArrowLeft" ? -rotStep : e.key === "ArrowRight" ? rotStep : 0);
         if (delta === 0) return;
         ensureCheckpoint();
         // rotate whole selection around bounding-box center (more intuitive)
@@ -200,7 +201,7 @@ export default function Canvas({
           const id = targets[0];
           const s = drawShapes.find((d) => d.id === id);
           if (!s) return;
-          const next = Math.round((s.rotateDeg ?? 0) + delta);
+          const next = Math.round(((s.rotateDeg ?? 0) + delta) * 10) / 10;
           updateShape(id, { rotateDeg: next }, { skipHistory: true });
           return;
         }
@@ -237,7 +238,7 @@ export default function Canvas({
           const ry = Math.round((relX * sind + relY * cosd) * 10) / 10;
           const newX = Math.round((centerX + rx) * 10) / 10;
           const newY = Math.round((centerY + ry) * 10) / 10;
-          const nextRot = Math.round((s.rotateDeg ?? 0) + delta);
+          const nextRot = Math.round(((s.rotateDeg ?? 0) + delta) * 10) / 10;
           updateShape(id, { x: newX, y: newY, rotateDeg: nextRot }, { skipHistory: true });
         }
         return;

--- a/frontend/src/components/Inspector.tsx
+++ b/frontend/src/components/Inspector.tsx
@@ -325,9 +325,14 @@ export default function Inspector({
     }
     // trace inputs are lifted into App state via props
     const threshold = traceParams?.threshold ?? 145;
-    const offset = traceParams?.offset ?? 0.1; // inches
+    const offset = traceParams?.offset ?? 0.05; // canonical unit is always inches
     const tokenSize = traceParams?.token ?? 3.0; // inches
     const resolution = traceParams?.resolution ?? 20;
+    // Offset is stored internally in inches regardless of the mm/inches
+    // display toggle, so convert for display/edit here rather than relying
+    // on the mm-based toDisplay/fromDisplay helpers above.
+    const offsetDisplay = useInches ? offset : offset * 25.4;
+    const offsetFromDisplayValue = (v: number) => (useInches ? v : v / 25.4);
 
     return (
       <aside className="panel panel-right">
@@ -337,8 +342,13 @@ export default function Inspector({
           <input type="number" min={0} max={255} value={threshold} onChange={(e) => setTraceParams?.({ threshold: parseInt(e.target.value || '0'), offset: offset, token: tokenSize, resolution })} />
         </div>
         <div className="field">
-          <label>Offset (inches)</label>
-          <input type="number" step="0.01" value={offset} onChange={(e) => setTraceParams?.({ threshold, offset: parseFloat(e.target.value || '0'), token: tokenSize, resolution })} />
+          <label>{`Offset (${unitLabel})`}</label>
+          <input
+            type="number"
+            step={useInches ? "0.01" : "0.1"}
+            value={Number(offsetDisplay.toFixed(useInches ? 3 : 2))}
+            onChange={(e) => setTraceParams?.({ threshold, offset: offsetFromDisplayValue(parseFloat(e.target.value || '0')), token: tokenSize, resolution })}
+          />
         </div>
         <div className="field">
           <label>Token Size</label>

--- a/frontend/src/components/Inspector.tsx
+++ b/frontend/src/components/Inspector.tsx
@@ -722,12 +722,12 @@ export default function Inspector({
                 <label>Rotate (deg)</label>
                 <input
                   type="number"
-                  step="1"
+                  step="0.1"
                   {...buildNumberField({
                     editKey: 'rotate',
                     getValue: () => selectedShape.rotateDeg ?? 0,
                     format: (n) => n.toFixed(1),
-                    transform: (n) => Math.round(n),
+                    transform: (n) => Math.round(n * 10) / 10,
                     commitValue: (n) => { if (selectedShape) updateShape(selectedShape.id, { rotateDeg: n }); },
                   })}
                   style={{ width: "100%" }}
@@ -875,7 +875,7 @@ export default function Inspector({
                         <label>Section Rotation (deg)</label>
                         <input
                           type="number"
-                          step="1"
+                          step="0.1"
                           {...buildNumberField({
                             editKey: 'sectionRotation',
                             getValue: () => selectedShape.sectionRotation ?? 0,
@@ -933,12 +933,12 @@ export default function Inspector({
                 <label>Rotate (deg)</label>
                 <input
                   type="number"
-                  step="1"
+                  step="0.1"
                   {...buildNumberField({
                     editKey: 'rotate',
                     getValue: () => selectedShape.rotateDeg ?? 0,
                     format: (n) => n.toFixed(1),
-                    transform: (n) => Math.round(n),
+                    transform: (n) => Math.round(n * 10) / 10,
                     commitValue: (n) => { if (selectedShape) updateShape(selectedShape.id, { rotateDeg: n }); },
                   })}
                       style={{ width: "100%" }}
@@ -1118,7 +1118,7 @@ export default function Inspector({
                         <label>Section Rotation (deg)</label>
                         <input
                           type="number"
-                          step="1"
+                          step="0.1"
                           {...buildNumberField({
                             editKey: 'sectionRotation',
                             getValue: () => selectedShape.sectionRotation ?? 0,
@@ -1195,12 +1195,12 @@ export default function Inspector({
                 <label>Rotate (deg)</label>
                 <input
                   type="number"
-                  step="1"
+                  step="0.1"
                   {...buildNumberField({
                     editKey: 'rotate',
                     getValue: () => selectedShape.rotateDeg ?? 0,
                     format: (n) => n.toFixed(1),
-                    transform: (n) => Math.round(n),
+                    transform: (n) => Math.round(n * 10) / 10,
                     commitValue: (n) => { if (selectedShape) updateShape(selectedShape.id, { rotateDeg: n }); },
                   })}
                   style={{ width: "100%" }}
@@ -1366,7 +1366,7 @@ export default function Inspector({
                           <label>Section Rotation (deg)</label>
                           <input
                             type="number"
-                            step="1"
+                            step="0.1"
                             {...buildNumberField({
                               editKey: 'sectionRotation',
                               getValue: () => selectedShape.sectionRotation ?? 0,

--- a/frontend/src/components/Inspector.tsx
+++ b/frontend/src/components/Inspector.tsx
@@ -202,6 +202,15 @@ export default function Inspector({
     };
   }
 
+  // Nudge the selected shape's rotation by a whole degree, independent of
+  // the 0.1-degree native spinner on the Rotate input.
+  const stepRotate = (delta: number) => {
+    if (!selectedShape) return;
+    const cur = selectedShape.rotateDeg ?? 0;
+    const next = Math.round((cur + delta) * 10) / 10;
+    updateShape(selectedShape.id, { rotateDeg: next });
+  };
+
   // When the selected shape's key properties change externally (for example
   // when the user drags or rotates the shape), and the inspector field is
   // not currently being edited, clear the edit buffer so the inspector shows
@@ -720,18 +729,22 @@ export default function Inspector({
               </div>
               <div className="field">
                 <label>Rotate (deg)</label>
-                <input
-                  type="number"
-                  step="0.1"
-                  {...buildNumberField({
-                    editKey: 'rotate',
-                    getValue: () => selectedShape.rotateDeg ?? 0,
-                    format: (n) => n.toFixed(1),
-                    transform: (n) => Math.round(n * 10) / 10,
-                    commitValue: (n) => { if (selectedShape) updateShape(selectedShape.id, { rotateDeg: n }); },
-                  })}
-                  style={{ width: "100%" }}
-                />
+                <div className="rotate-step-row">
+                  <button type="button" className="step-btn" title="Rotate -1 degree" onClick={() => stepRotate(-1)}>-1&deg;</button>
+                  <input
+                    type="number"
+                    step="0.1"
+                    {...buildNumberField({
+                      editKey: 'rotate',
+                      getValue: () => selectedShape.rotateDeg ?? 0,
+                      format: (n) => n.toFixed(1),
+                      transform: (n) => Math.round(n * 10) / 10,
+                      commitValue: (n) => { if (selectedShape) updateShape(selectedShape.id, { rotateDeg: n }); },
+                    })}
+                    style={{ flex: 1, minWidth: 0 }}
+                  />
+                  <button type="button" className="step-btn" title="Rotate +1 degree" onClick={() => stepRotate(1)}>+1&deg;</button>
+                </div>
               </div>
 
               {/* Split to Sections - for Text Cut type shapes */}
@@ -931,18 +944,22 @@ export default function Inspector({
             <>
               <div className="field">
                 <label>Rotate (deg)</label>
-                <input
-                  type="number"
-                  step="0.1"
-                  {...buildNumberField({
-                    editKey: 'rotate',
-                    getValue: () => selectedShape.rotateDeg ?? 0,
-                    format: (n) => n.toFixed(1),
-                    transform: (n) => Math.round(n * 10) / 10,
-                    commitValue: (n) => { if (selectedShape) updateShape(selectedShape.id, { rotateDeg: n }); },
-                  })}
-                      style={{ width: "100%" }}
-                />
+                <div className="rotate-step-row">
+                  <button type="button" className="step-btn" title="Rotate -1 degree" onClick={() => stepRotate(-1)}>-1&deg;</button>
+                  <input
+                    type="number"
+                    step="0.1"
+                    {...buildNumberField({
+                      editKey: 'rotate',
+                      getValue: () => selectedShape.rotateDeg ?? 0,
+                      format: (n) => n.toFixed(1),
+                      transform: (n) => Math.round(n * 10) / 10,
+                      commitValue: (n) => { if (selectedShape) updateShape(selectedShape.id, { rotateDeg: n }); },
+                    })}
+                    style={{ flex: 1, minWidth: 0 }}
+                  />
+                  <button type="button" className="step-btn" title="Rotate +1 degree" onClick={() => stepRotate(1)}>+1&deg;</button>
+                </div>
               </div>
               <div className="field">
                 <label>Scale</label>
@@ -1193,18 +1210,22 @@ export default function Inspector({
               { /* radius removed: oval uses width/height only */ }
               <div className="field">
                 <label>Rotate (deg)</label>
-                <input
-                  type="number"
-                  step="0.1"
-                  {...buildNumberField({
-                    editKey: 'rotate',
-                    getValue: () => selectedShape.rotateDeg ?? 0,
-                    format: (n) => n.toFixed(1),
-                    transform: (n) => Math.round(n * 10) / 10,
-                    commitValue: (n) => { if (selectedShape) updateShape(selectedShape.id, { rotateDeg: n }); },
-                  })}
-                  style={{ width: "100%" }}
-                />
+                <div className="rotate-step-row">
+                  <button type="button" className="step-btn" title="Rotate -1 degree" onClick={() => stepRotate(-1)}>-1&deg;</button>
+                  <input
+                    type="number"
+                    step="0.1"
+                    {...buildNumberField({
+                      editKey: 'rotate',
+                      getValue: () => selectedShape.rotateDeg ?? 0,
+                      format: (n) => n.toFixed(1),
+                      transform: (n) => Math.round(n * 10) / 10,
+                      commitValue: (n) => { if (selectedShape) updateShape(selectedShape.id, { rotateDeg: n }); },
+                    })}
+                    style={{ flex: 1, minWidth: 0 }}
+                  />
+                  <button type="button" className="step-btn" title="Rotate +1 degree" onClick={() => stepRotate(1)}>+1&deg;</button>
+                </div>
               </div>
               <div className="field">
                 <label>{`Depth (${unitLabel})`}</label>

--- a/src/processing.py
+++ b/src/processing.py
@@ -28,9 +28,9 @@ scad_file_path = None  # Declare scad_file_path as a global variable
 
 def get_threshold_input(threshold_entry, offset_entry, token_entry, resolution_entry):
     global offset, token, resolution
-    # Defaults: threshold 145, offset 0.1 (inches), token 3.0 (inches), resolution 20
+    # Defaults: threshold 145, offset 0.05 (inches), token 3.0 (inches), resolution 20
     threshold_input = validate_input(threshold_entry.text(), 145, 0, 255)
-    offset = validate_input(offset_entry.text(), 0.1)
+    offset = validate_input(offset_entry.text(), 0.05)
     token = validate_input(token_entry.text(), 3.000)
     resolution = validate_input(resolution_entry.text(), 20)
     return threshold_input
@@ -1214,7 +1214,7 @@ def cli_main(argv=None):
     parser.add_argument('input_path', nargs='?')
     parser.add_argument('out_dir', nargs='?', default='processing_output')
     parser.add_argument('--threshold', type=float, default=145)
-    parser.add_argument('--offset', type=float, default=0.1)
+    parser.add_argument('--offset', type=float, default=0.05)
     parser.add_argument('--token', type=float, default=3.0)
     parser.add_argument('--resolution', type=int, default=20)
     parser.add_argument('--projectdir', type=str, default=None)


### PR DESCRIPTION
Hi @tkubic 

I have been using this fantastic tool to sort out my tool chest. Using this GSM2.0 with a cheap 600x600 LED lighting panel generates very good results. 

Here are some refinements you may want to consider from many hours of use:

1. It didn't run on my Mac, small tweak to how it creates the python path.
2. In the "Trace Object" tab the offset was always in inches regardless of whether inches or mm selected at top. I have made this reflect the selected units.
3. Halved the default offset as 0.1inch it always left the tools flopping around.
4. I found that sometimes 1 degree rotation was just too much making it impossible to align tools, so I made the spinner 0.1 degrees and added separate +1 and -1 degree rotation buttons.

I hope you like the updates

Cheers